### PR TITLE
fix(localization): 🌐 proper established localization in modals

### DIFF
--- a/resources/lang/de/log.php
+++ b/resources/lang/de/log.php
@@ -31,10 +31,10 @@ return [
                 'label' => 'Ansehen',
             ],
             'download' => [
-                'label' => 'Herunterladen',
+                'label' => 'Log :log herunterladen',
             ],
             'delete' => [
-                'label' => 'Löschen :record',
+                'label' => 'Log :log löschen',
                 'success' => 'Log erfolgreich gelöscht',
                 'error' => 'Fehler beim Löschen des Logs',
             ],

--- a/resources/lang/en/log.php
+++ b/resources/lang/en/log.php
@@ -31,10 +31,10 @@ return [
                 'label' => 'View',
             ],
             'download' => [
-                'label' => 'Download',
+                'label' => 'Download log :log',
             ],
             'delete' => [
-                'label' => 'Delete :record',
+                'label' => 'Delete log :log',
                 'success' => 'Log deleted successfully',
                 'error' => 'Error deleting the log',
             ],

--- a/resources/lang/es/log.php
+++ b/resources/lang/es/log.php
@@ -31,10 +31,10 @@ return [
                 'label' => 'Ver',
             ],
             'download' => [
-                'label' => 'Descargar',
+                'label' => 'Descargar el log del :log',
             ],
             'delete' => [
-                'label' => 'Eliminar :record',
+                'label' => 'Eliminar el log del :log',
                 'success' => 'Log eliminado con éxito',
                 'error' => 'Error al eliminar el log',
             ],

--- a/resources/lang/fr/log.php
+++ b/resources/lang/fr/log.php
@@ -31,10 +31,10 @@ return [
                 'label' => 'Voir',
             ],
             'download' => [
-                'label' => 'Télécharger',
+                'label' => 'Télécharger le log :log',
             ],
             'delete' => [
-                'label' => 'Supprimer :record',
+                'label' => 'Supprimer le log :log',
                 'success' => 'Log supprimé avec succès',
                 'error' => 'Erreur lors de la suppression du log',
             ],

--- a/resources/lang/it/log.php
+++ b/resources/lang/it/log.php
@@ -31,10 +31,10 @@ return [
                 'label' => 'Vedi',
             ],
             'download' => [
-                'label' => 'Scarica',
+                'label' => 'Scarica il log :log',
             ],
             'delete' => [
-                'label' => 'Elimina :record',
+                'label' => 'Elimina il log :log',
                 'success' => 'Log eliminato con successo',
                 'error' => 'Errore durante l\'eliminazione del log',
             ],

--- a/resources/lang/pt/log.php
+++ b/resources/lang/pt/log.php
@@ -7,7 +7,7 @@ return [
         'title' => 'Visualizador de logs',
     ],
     'show' => [
-        'title' => 'Ver o log :log',
+        'title' => 'Ver log :log',
     ],
     'navigation' => [
         'group' => 'Logs',
@@ -31,10 +31,10 @@ return [
                 'label' => 'Ver',
             ],
             'download' => [
-                'label' => 'Baixar',
+                'label' => 'Baixar log :log',
             ],
             'delete' => [
-                'label' => 'Excluir :record',
+                'label' => 'Excluir log :log',
                 'success' => 'Log excluído com sucesso',
                 'error' => 'Erro ao excluir o log',
             ],

--- a/src/Pages/ListLogs.php
+++ b/src/Pages/ListLogs.php
@@ -14,6 +14,7 @@ use Filament\Tables;
 use Filament\Tables\Concerns\InteractsWithTable;
 use Filament\Tables\Contracts\HasTable;
 use Filament\Tables\Table;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Config;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 
@@ -77,6 +78,11 @@ class ListLogs extends Page implements HasTable
                     ->hiddenLabel()
                     ->button()
                     ->label(__('filament-log-viewer::log.table.actions.download.label'))
+                    ->modalHeading(
+                        fn (LogStat $record) => __('filament-log-viewer::log.table.actions.download.label', [
+                            'log' => Carbon::parse($record->date)->isoFormat('LL'),
+                        ]),
+                    )
                     ->color('success')
                     ->icon('fas-download')
                     ->requiresConfirmation()
@@ -88,6 +94,11 @@ class ListLogs extends Page implements HasTable
                     ->hiddenLabel()
                     ->button()
                     ->label(__('filament-log-viewer::log.table.actions.delete.label'))
+                    ->modalHeading(
+                        fn (LogStat $record) => __('filament-log-viewer::log.table.actions.delete.label', [
+                            'log' => Carbon::parse($record->date)->isoFormat('LL'),
+                        ]),
+                    )
                     ->color('danger')
                     ->icon('fas-trash')
                     ->requiresConfirmation()

--- a/src/Pages/ViewLog.php
+++ b/src/Pages/ViewLog.php
@@ -139,8 +139,13 @@ class ViewLog extends Page implements HasTable
         return [
             Actions\Action::make('download')
                 ->hiddenLabel()
-                ->tooltip(__('filament-log-viewer::log.table.actions.download.label'))
+                ->tooltip(__('filament-log-viewer::log.table.actions.download.label', [
+                    'log' => Carbon::parse($this->record->date)->isoFormat('LL'),
+                ]))
                 ->button()
+                ->modalHeading(__('filament-log-viewer::log.table.actions.download.label', [
+                    'log' => Carbon::parse($this->record->date)->isoFormat('LL'),
+                ]))
                 ->label(__('filament-log-viewer::log.table.actions.download.label'))
                 ->color('success')
                 ->icon('fas-download')
@@ -152,12 +157,12 @@ class ViewLog extends Page implements HasTable
             DeleteAction::make()
                 ->hiddenLabel()
                 ->tooltip(__('filament-log-viewer::log.table.actions.delete.label', [
-                    'record' => $this->record->date,
+                    'log' => Carbon::parse($this->record->date)->isoFormat('LL'),
                 ]))
                 ->hidden(false)
                 ->button()
                 ->modalHeading(__('filament-log-viewer::log.table.actions.delete.label', [
-                    'record' => $this->record->date,
+                    'log' => Carbon::parse($this->record->date)->isoFormat('LL'),
                 ]))
                 ->label(__('filament-log-viewer::log.table.actions.delete.label'))
                 ->color('danger')


### PR DESCRIPTION
- Improves the clarity of log download and delete labels by including a formatted date.
- Updates language files to use the `:log` placeholder and format the date via Carbon in the modal headings of the actions.

Resolves #6.