### PR TITLE
feat(bulkActions): ✨ add bulk delete and download actions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
     }
   },
   "require": {
+    "ext-zip": "*",
     "php": "^8.3|^8.4",
     "eightynine/filament-advanced-widgets": "^3.0",
     "owenvoke/blade-fontawesome": "^2.9",

--- a/resources/lang/de/log.php
+++ b/resources/lang/de/log.php
@@ -32,6 +32,10 @@ return [
             ],
             'download' => [
                 'label' => 'Herunterladen',
+                'bulk' => [
+                    'label' => 'Ausgewählte herunterladen',
+                    'error' => 'Fehler beim Herunterladen der Logs',
+                ],
             ],
             'delete' => [
                 'label' => 'Löschen :record',

--- a/resources/lang/de/log.php
+++ b/resources/lang/de/log.php
@@ -37,6 +37,9 @@ return [
                 'label' => 'Löschen :record',
                 'success' => 'Log erfolgreich gelöscht',
                 'error' => 'Fehler beim Löschen des Logs',
+                'bulk' => [
+                    'label' => 'Ausgewählte Logs löschen',
+                ],
             ],
             'close' => [
                 'label' => 'Zurück',

--- a/resources/lang/en/log.php
+++ b/resources/lang/en/log.php
@@ -37,6 +37,9 @@ return [
                 'label' => 'Delete :record',
                 'success' => 'Log deleted successfully',
                 'error' => 'Error deleting the log',
+                'bulk' => [
+                    'label' => 'Delete selected logs',
+                ],
             ],
             'close' => [
                 'label' => 'Back',

--- a/resources/lang/en/log.php
+++ b/resources/lang/en/log.php
@@ -32,6 +32,10 @@ return [
             ],
             'download' => [
                 'label' => 'Download',
+                'bulk' => [
+                    'label' => 'Download logs',
+                    'error' => 'Error downloading the logs',
+                ],
             ],
             'delete' => [
                 'label' => 'Delete :record',

--- a/resources/lang/es/log.php
+++ b/resources/lang/es/log.php
@@ -37,6 +37,9 @@ return [
                 'label' => 'Eliminar :record',
                 'success' => 'Log eliminado con éxito',
                 'error' => 'Error al eliminar el log',
+                'bulk' => [
+                    'label' => 'Eliminar logs seleccionados',
+                ],
             ],
             'close' => [
                 'label' => 'Volver',

--- a/resources/lang/es/log.php
+++ b/resources/lang/es/log.php
@@ -32,6 +32,10 @@ return [
             ],
             'download' => [
                 'label' => 'Descargar',
+                'bulk' => [
+                    'label' => 'Descargar seleccionados',
+                    'error' => 'Error al descargar los logs',
+                ],
             ],
             'delete' => [
                 'label' => 'Eliminar :record',

--- a/resources/lang/fr/log.php
+++ b/resources/lang/fr/log.php
@@ -32,6 +32,10 @@ return [
             ],
             'download' => [
                 'label' => 'Télécharger',
+                'bulk' => [
+                    'label' => 'Télécharger sélectionnés',
+                    'error' => 'Erreur lors du téléchargement des logs',
+                ],
             ],
             'delete' => [
                 'label' => 'Supprimer :record',

--- a/resources/lang/fr/log.php
+++ b/resources/lang/fr/log.php
@@ -37,6 +37,9 @@ return [
                 'label' => 'Supprimer :record',
                 'success' => 'Log supprimé avec succès',
                 'error' => 'Erreur lors de la suppression du log',
+                'bulk' => [
+                    'label' => 'Supprimer les logs sélectionnés',
+                ],
             ],
             'close' => [
                 'label' => 'Retour',

--- a/resources/lang/it/log.php
+++ b/resources/lang/it/log.php
@@ -32,6 +32,10 @@ return [
             ],
             'download' => [
                 'label' => 'Scarica',
+                'bulk' => [
+                    'label' => 'Scarica i log selezionati',
+                    'error' => 'Errore durante il download dei log',
+                ],
             ],
             'delete' => [
                 'label' => 'Elimina :record',

--- a/resources/lang/it/log.php
+++ b/resources/lang/it/log.php
@@ -37,6 +37,9 @@ return [
                 'label' => 'Elimina :record',
                 'success' => 'Log eliminato con successo',
                 'error' => 'Errore durante l\'eliminazione del log',
+                'bulk' => [
+                    'label' => 'Elimina i log selezionati',
+                ],
             ],
             'close' => [
                 'label' => 'Indietro',

--- a/resources/lang/pt/log.php
+++ b/resources/lang/pt/log.php
@@ -32,6 +32,10 @@ return [
             ],
             'download' => [
                 'label' => 'Baixar',
+                'bulk' => [
+                    'label' => 'Baixar selecionados',
+                    'error' => 'Erro ao baixar os logs',
+                ],
             ],
             'delete' => [
                 'label' => 'Excluir :record',

--- a/resources/lang/pt/log.php
+++ b/resources/lang/pt/log.php
@@ -37,6 +37,9 @@ return [
                 'label' => 'Excluir :record',
                 'success' => 'Log excluído com sucesso',
                 'error' => 'Erro ao excluir o log',
+                'bulk' => [
+                    'label' => 'Excluir logs selecionados',
+                ],
             ],
             'close' => [
                 'label' => 'Voltar',

--- a/src/Actions/DownloadZipAction.php
+++ b/src/Actions/DownloadZipAction.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Boquizo\FilamentLogViewer\Actions;
+
+use RuntimeException;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use ZipArchive;
+
+class DownloadZipAction
+{
+    public static function execute(array $files): BinaryFileResponse
+    {
+        return (new self())($files);
+    }
+
+    /**
+     * @throws RuntimeException
+     */
+    public function __invoke(array $files): BinaryFileResponse
+    {
+        $zip = new ZipArchive();
+        $filename = 'logs.zip';
+        $zipPath = storage_path("logs/{$filename}");
+
+        if ($zip->open($zipPath, ZipArchive::CREATE | ZipArchive::OVERWRITE) === true) {
+            foreach ($this->extractPaths($files) as $path) {
+                if (file_exists($path)) {
+                    $zip->addFile($path, basename($path));
+                }
+            }
+
+            $zip->close();
+
+            return response()->download($zipPath, $filename)
+                ->deleteFileAfterSend();
+        }
+
+        throw new RuntimeException('Failed to create zip file.');
+    }
+
+    private function extractPaths(array $files): array
+    {
+        return collect($files)
+            ->map(
+                static fn (string $log): string => ExtractLogPathAction::execute($log),
+            )
+            ->all();
+    }
+}

--- a/src/FilamentLogViewerPlugin.php
+++ b/src/FilamentLogViewerPlugin.php
@@ -4,6 +4,7 @@ namespace Boquizo\FilamentLogViewer;
 
 use Boquizo\FilamentLogViewer\Actions\DeleteLogAction;
 use Boquizo\FilamentLogViewer\Actions\DownloadLogAction;
+use Boquizo\FilamentLogViewer\Actions\DownloadZipAction;
 use Boquizo\FilamentLogViewer\Actions\ExtractLogByDateAction;
 use Boquizo\FilamentLogViewer\Entities\Log;
 use Boquizo\FilamentLogViewer\Entities\LogCollection;
@@ -195,5 +196,10 @@ class FilamentLogViewerPlugin implements Plugin
     public function downloadLog(string $date): BinaryFileResponse
     {
         return DownloadLogAction::execute($date);
+    }
+
+    public function downloadLogs(array $files): BinaryFileResponse
+    {
+        return DownloadZipAction::execute($files);
     }
 }

--- a/src/Pages/ListLogs.php
+++ b/src/Pages/ListLogs.php
@@ -14,6 +14,9 @@ use Filament\Tables;
 use Filament\Tables\Concerns\InteractsWithTable;
 use Filament\Tables\Contracts\HasTable;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Config;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 
@@ -102,6 +105,22 @@ class ListLogs extends Page implements HasTable
                                 ->danger()
                                 ->send();
                     }),
+            ])
+            ->bulkActions([
+                Tables\Actions\BulkActionGroup::make([
+                    Tables\Actions\DeleteBulkAction::make()
+                        ->modalHeading(__('filament-log-viewer::log.table.actions.delete.bulk.label'))
+                        ->action(function (Tables\Actions\DeleteBulkAction $action): void {
+                            $action->process(static function (Collection $records): void {
+                                $records->each(
+                                    fn (LogStat $record): bool => FilamentLogViewerPlugin::get()
+                                        ->deleteLog($record->date)
+                                );
+                            });
+
+                            $action->success();
+                        }),
+                ]),
             ]);
     }
 


### PR DESCRIPTION
Adds functionality to download multiple log files as a ZIP archive.

- Add DeleteBulkAction into the `ListLogs` table
- Introduces a new `DownloadZipAction` to handle the zipping and download process.
- Adds translations for the bulk download action label and error message in multiple languages.
- Requires the `ext-zip` PHP extension.

This enhances the user experience by allowing users to easily download and delete multiple logs at once.

Resolves #5.