### PR TITLE
fix(slug): 🐛 fully personalizable slug

### DIFF
--- a/src/FilamentLogViewerPlugin.php
+++ b/src/FilamentLogViewerPlugin.php
@@ -16,7 +16,6 @@ use Filament\Contracts\Plugin;
 use Filament\FilamentManager;
 use Filament\Panel;
 use Filament\Support\Concerns\EvaluatesClosures;
-use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Session;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 
@@ -150,11 +149,6 @@ class FilamentLogViewerPlugin implements Plugin
     {
         return $this->evaluate($this->navigationLabel)
             ?? __('filament-log-viewer::log.navigation.label');
-    }
-
-    public function getSlug(): string
-    {
-        return Config::string('filament-log-viewer.resource.slug', 'logs');
     }
 
     public function getViewerStatsTable(): StatsTable

--- a/src/Pages/ListLogs.php
+++ b/src/Pages/ListLogs.php
@@ -181,7 +181,7 @@ class ListLogs extends Page implements HasTable
 
     public static function getSlug(): string
     {
-        return FilamentLogViewerPlugin::get()->getSlug();
+        return Config::string('filament-log-viewer.resource.slug', 'logs');
     }
 
     public static function canAccess(): bool

--- a/src/Pages/ViewLog.php
+++ b/src/Pages/ViewLog.php
@@ -243,7 +243,9 @@ class ViewLog extends Page implements HasTable
 
     public static function getSlug(): string
     {
-        return FilamentLogViewerPlugin::get()->getSlug() . '/{record}';
+        $slug = Config::string('filament-log-viewer.resource.slug', 'logs');
+
+        return "{$slug}/{record}";
     }
 
     public function mount(string $record): void


### PR DESCRIPTION
- Allows users to fully personalize the resource slug via config.
- Removes the `getSlug` method from the plugin class and uses the config value directly in the Livewire components.

Related with #13, #14 and #1 