### PR TITLE
fix(config) : 🐛 set fallback log driver to 'stack' in config

### DIFF
--- a/config/filament-log-viewer.php
+++ b/config/filament-log-viewer.php
@@ -11,7 +11,7 @@ return [
     | -----------------------------------------------------------------
      */
 
-    'driver' => env('FILAMENT_LOG_VIEWER_DRIVER', env('LOG_CHANNEL')),
+    'driver' => env('FILAMENT_LOG_VIEWER_DRIVER', env('LOG_CHANNEL', 'stack')),
 
     /* -----------------------------------------------------------------
     | Resource configuration


### PR DESCRIPTION
```php
/*
 |--------------------------------------------------------------------------
 | Default Log Channel
 |--------------------------------------------------------------------------
 |
 | This option defines the default log channel that is utilized to write
 | messages to your logs. The value provided here should match one of
 | the channels present in the list of "channels" configured below.
 |
*/

'default' => env('LOG_CHANNEL', 'stack'),
```

https://github.com/laravel/framework/blob/12.x/config/logging.php#L21