### PR TITLE
chore: ⬇️ php 8.2 support until EOL

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Based on [ARCANEDEV LogViewer](https://github.com/ARCANEDEV/LogViewer).
 ### Prerequisites 📋
 
 - Composer.
-- PHP version 8.3 or higher.
+- PHP version 8.2 or higher.
 
 ## Versions 🔖
 | Plugin | Filament |

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
   },
   "require": {
     "ext-zip": "*",
-    "php": "^8.3|^8.4",
+    "php": "^8.2|^8.3|^8.4",
     "owenvoke/blade-fontawesome": "^2.9"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
   "require": {
     "ext-zip": "*",
     "php": "^8.2|^8.3|^8.4",
-    "owenvoke/blade-fontawesome": "^2.9"
+    "owenvoke/blade-fontawesome": "^2.9",
+    "symfony/polyfill-php83": "^1.33"
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^3.64",

--- a/src/Utils/Level.php
+++ b/src/Utils/Level.php
@@ -10,7 +10,7 @@ enum Level: string
 {
     // This is a special case, it's not a level itself.
     // It's used to represent all levels and avoid magic strings.
-    const string ALL = 'all';
+    const ALL = 'all';
 
     case Emergency = 'emergency';
     case Alert = 'alert';

--- a/src/Utils/Parser.php
+++ b/src/Utils/Parser.php
@@ -8,9 +8,9 @@ use Illuminate\Support\Str;
 
 class Parser
 {
-    public const string DATE_PATTERN = '\d{4}(-\d{2}){2}';
-    public const string TIME_PATTERN = '\d{2}(:\d{2}){2}';
-    public const string DATETIME_PATTERN = self::DATE_PATTERN . ' ' . self::TIME_PATTERN;
+    public const DATE_PATTERN = '\d{4}(-\d{2}){2}';
+    public const TIME_PATTERN = '\d{2}(:\d{2}){2}';
+    public const DATETIME_PATTERN = self::DATE_PATTERN . ' ' . self::TIME_PATTERN;
 
     protected static array $parsed = [];
 


### PR DESCRIPTION
Closes #39 
https://filamentphp.com/docs/4.x/introduction/installation
<img width="319" height="251" alt="image" src="https://github.com/user-attachments/assets/85983f6b-87c5-4d58-a11c-c4f17bea9dc6" />

Filament didn't require 8.3 and it works just fine with 8.2 so why bump it ?