### PR TITLE
fix: 🐛 use DIRECTORY_SEPARATOR for log path sanitization to resolve 404 on Linux/Unix

### DIFF
--- a/src/Entities/LogCollection.php
+++ b/src/Entities/LogCollection.php
@@ -22,7 +22,7 @@ class LogCollection extends LazyCollection
                 $storagePath = Config::string('filament-log-viewer.storage_path', storage_path('logs'));
 
                 foreach (ExtractNamesUseCase::execute() as $date => $path) {
-                    $path = Str::replace("{$storagePath}\\", '', $path);
+                    $path = Str::replace($storagePath . DIRECTORY_SEPARATOR, '', $path);
                     $mode = $driver === 'raw' ? $path : $date;
 
                     yield $mode => Log::make(


### PR DESCRIPTION
This PR fixes a 404 error encountered when viewing log files on Linux, macOS, or environments using forward slashes. The issue was caused by LogCollection.php hardcoding a backslash (\\) to strip the storage path from the full log path, which failed to sanitize paths correctly on non-Windows systems, resulting in broken links. I have updated the logic to use the system's DIRECTORY_SEPARATOR constant instead, ensuring that the storage path is correctly removed regardless of the operating system. I verified this fix with a script simulating both Windows and Linux path styles, confirming that it now correctly generates the relative filenames needed for the viewer to work.