### PR TITLE
feat: ✨ log viewer modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,35 @@ LOG_CHANNEL=daily
 FILAMENT_LOG_VIEWER_DRIVER=raw
 ```
 
+### View in modal
+
+By default, clicking "View" opens the log in a full page. You can enable view-in-modal mode to show logs in a modal instead:
+
+**Via config** (`.env`):
+
+```
+FILAMENT_LOG_VIEWER_VIEW_IN_MODAL=true
+```
+
+**Or programmatically** (in your panel provider):
+
+```php
+->plugins([
+    \Boquizo\FilamentLogViewer\FilamentLogViewerPlugin::make()
+        ->viewInModal(),
+])
+```
+
+When using modal view, you may want to hide the ViewLog page from direct URL access by passing a custom page that denies access:
+
+```php
+->plugins([
+    \Boquizo\FilamentLogViewer\FilamentLogViewerPlugin::make()
+        ->viewInModal()
+        ->viewLog(\App\Filament\LogViewer\Pages\ViewLogDenied::class),
+])
+```
+
 ### Others configurations
 
 ```php

--- a/config/filament-log-viewer.php
+++ b/config/filament-log-viewer.php
@@ -24,6 +24,16 @@ return [
     ],
 
     /* -----------------------------------------------------------------
+    | View log in modal
+    | -----------------------------------------------------------------
+    | When true, clicking "View" opens the log in a modal instead of a
+    | separate page. Set to false to use the full-page ViewLog page.
+    | -----------------------------------------------------------------
+     */
+
+    'view_in_modal' => env('FILAMENT_LOG_VIEWER_VIEW_IN_MODAL', false),
+
+    /* -----------------------------------------------------------------
     | Logs files can be cleared
     | -----------------------------------------------------------------
     */

--- a/resources/lang/ar/log.php
+++ b/resources/lang/ar/log.php
@@ -61,6 +61,17 @@ return [
                 'label' => 'رجوع',
             ],
         ],
+        'modal' => [
+            'search_placeholder' => 'البحث في السجلات…',
+            'go_to_top' => 'الانتقال إلى الأعلى',
+            'go_to_bottom' => 'الانتقال إلى الأسفل',
+            'top' => 'أعلى',
+            'bottom' => 'أسفل',
+            'no_matching_entries' => 'لا توجد إدخالات سجل مطابقة.',
+            'no_entries' => 'لا توجد إدخالات سجل.',
+            'context' => 'السياق',
+            'stack_trace' => 'تتبع المكدس',
+        ],
         'detail' => [
             'title' => 'التفاصيل',
             'file_path' => 'مسار الملف',

--- a/resources/lang/de/log.php
+++ b/resources/lang/de/log.php
@@ -61,6 +61,17 @@ return [
                 'label' => 'Zurück',
             ],
         ],
+        'modal' => [
+            'search_placeholder' => 'Logs durchsuchen…',
+            'go_to_top' => 'Nach oben',
+            'go_to_bottom' => 'Nach unten',
+            'top' => 'Oben',
+            'bottom' => 'Unten',
+            'no_matching_entries' => 'Keine passenden Log-Einträge.',
+            'no_entries' => 'Keine Log-Einträge.',
+            'context' => 'Kontext',
+            'stack_trace' => 'Stack-Trace',
+        ],
         'detail' => [
             'title' => 'Detail',
             'file_path' => 'Dateipfad',

--- a/resources/lang/en/log.php
+++ b/resources/lang/en/log.php
@@ -61,6 +61,17 @@ return [
                 'label' => 'Back',
             ],
         ],
+        'modal' => [
+            'search_placeholder' => 'Search logs…',
+            'go_to_top' => 'Go to top',
+            'go_to_bottom' => 'Go to bottom',
+            'top' => 'Top',
+            'bottom' => 'Bottom',
+            'no_matching_entries' => 'No matching log entries.',
+            'no_entries' => 'No log entries.',
+            'context' => 'Context',
+            'stack_trace' => 'Stack trace',
+        ],
         'detail' => [
             'title' => 'Detail',
             'file_path' => 'File Path',

--- a/resources/lang/es/log.php
+++ b/resources/lang/es/log.php
@@ -61,6 +61,17 @@ return [
                 'label' => 'Volver',
             ],
         ],
+        'modal' => [
+            'search_placeholder' => 'Buscar en logs…',
+            'go_to_top' => 'Ir arriba',
+            'go_to_bottom' => 'Ir abajo',
+            'top' => 'Arriba',
+            'bottom' => 'Abajo',
+            'no_matching_entries' => 'No hay entradas de log coincidentes.',
+            'no_entries' => 'No hay entradas de log.',
+            'context' => 'Contexto',
+            'stack_trace' => 'Seguimiento de pila',
+        ],
         'detail' => [
             'title' => 'Detalle',
             'file_path' => 'Ruta del archivo',

--- a/resources/lang/fr/log.php
+++ b/resources/lang/fr/log.php
@@ -61,6 +61,17 @@ return [
                 'label' => 'Retour',
             ],
         ],
+        'modal' => [
+            'search_placeholder' => 'Rechercher dans les logs…',
+            'go_to_top' => 'Aller en haut',
+            'go_to_bottom' => 'Aller en bas',
+            'top' => 'Haut',
+            'bottom' => 'Bas',
+            'no_matching_entries' => 'Aucune entrée de journal correspondante.',
+            'no_entries' => 'Aucune entrée de journal.',
+            'context' => 'Contexte',
+            'stack_trace' => 'Trace de la pile',
+        ],
         'detail' => [
             'title' => 'Détail',
             'file_path' => 'Chemin du fichier',

--- a/resources/lang/it/log.php
+++ b/resources/lang/it/log.php
@@ -61,6 +61,17 @@ return [
                 'label' => 'Indietro',
             ],
         ],
+        'modal' => [
+            'search_placeholder' => 'Cerca nei log…',
+            'go_to_top' => 'Vai in alto',
+            'go_to_bottom' => 'Vai in basso',
+            'top' => 'Alto',
+            'bottom' => 'Basso',
+            'no_matching_entries' => 'Nessuna voce di log corrispondente.',
+            'no_entries' => 'Nessuna voce di log.',
+            'context' => 'Contesto',
+            'stack_trace' => 'Traccia dello stack',
+        ],
         'detail' => [
             'title' => 'Dettaglio',
             'file_path' => 'Percorso del file',

--- a/resources/lang/pl/log.php
+++ b/resources/lang/pl/log.php
@@ -61,6 +61,17 @@ return [
                 'label' => 'Powrót',
             ],
         ],
+        'modal' => [
+            'search_placeholder' => 'Szukaj w logach…',
+            'go_to_top' => 'Idź do góry',
+            'go_to_bottom' => 'Idź na dół',
+            'top' => 'Góra',
+            'bottom' => 'Dół',
+            'no_matching_entries' => 'Brak pasujących wpisów w logu.',
+            'no_entries' => 'Brak wpisów w logu.',
+            'context' => 'Kontekst',
+            'stack_trace' => 'Ślad stosu',
+        ],
         'detail' => [
             'title' => 'Szczegóły',
             'file_path' => 'Ścieżka pliku',

--- a/resources/lang/pt/log.php
+++ b/resources/lang/pt/log.php
@@ -61,6 +61,17 @@ return [
                 'label' => 'Voltar',
             ],
         ],
+        'modal' => [
+            'search_placeholder' => 'Pesquisar nos logs…',
+            'go_to_top' => 'Ir para o topo',
+            'go_to_bottom' => 'Ir para o final',
+            'top' => 'Topo',
+            'bottom' => 'Final',
+            'no_matching_entries' => 'Nenhuma entrada de log correspondente.',
+            'no_entries' => 'Nenhuma entrada de log.',
+            'context' => 'Contexto',
+            'stack_trace' => 'Rastreamento da pilha',
+        ],
         'detail' => [
             'title' => 'Detalhes',
             'file_path' => 'Caminho do arquivo',

--- a/resources/lang/ru/log.php
+++ b/resources/lang/ru/log.php
@@ -61,6 +61,17 @@ return [
                 'label' => 'Назад',
             ],
         ],
+        'modal' => [
+            'search_placeholder' => 'Поиск в логах…',
+            'go_to_top' => 'Перейти в начало',
+            'go_to_bottom' => 'Перейти в конец',
+            'top' => 'Вверх',
+            'bottom' => 'Вниз',
+            'no_matching_entries' => 'Нет подходящих записей в логе.',
+            'no_entries' => 'Нет записей в логе.',
+            'context' => 'Контекст',
+            'stack_trace' => 'Трассировка стека',
+        ],
         'detail' => [
             'title' => 'Детали',
             'file_path' => 'Путь к файлу',

--- a/resources/views/log-viewer-modal.blade.php
+++ b/resources/views/log-viewer-modal.blade.php
@@ -64,7 +64,7 @@
                     <input
                         type="search"
                         x-model="search"
-                        placeholder="{{ __('filament-log-viewer::log.modal.search_placeholder') }}"
+                        placeholder="{{ __('filament-log-viewer::log.table.modal.search_placeholder') }}"
                         class="w-full rounded-lg border-gray-300 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 text-sm px-4 py-2.5 focus:border-primary-500 focus:ring-primary-500"
                     />
                 </div>
@@ -72,24 +72,24 @@
                     type="button"
                     @click="scrollToTop"
                     class="shrink-0 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-xs font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700"
-                    title="{{ __('filament-log-viewer::log.modal.go_to_top') }}"
+                    title="{{ __('filament-log-viewer::log.table.modal.go_to_top') }}"
                 >
-                    ↑ {{ __('filament-log-viewer::log.modal.top') }}
+                    ↑ {{ __('filament-log-viewer::log.table.modal.top') }}
                 </button>
                 <button
                     type="button"
                     @click="scrollToBottom"
                     class="shrink-0 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-xs font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700"
-                    title="{{ __('filament-log-viewer::log.modal.go_to_bottom') }}"
+                    title="{{ __('filament-log-viewer::log.table.modal.go_to_bottom') }}"
                 >
-                    ↓ {{ __('filament-log-viewer::log.modal.bottom') }}
+                    ↓ {{ __('filament-log-viewer::log.table.modal.bottom') }}
                 </button>
             </div>
             <div
                 x-ref="scrollContainer"
                 class="max-h-[32rem] overflow-y-auto divide-y divide-gray-200 dark:divide-gray-700"
             >
-                <div x-show="filteredEntries.length === 0" class="p-8 text-center text-sm text-gray-500 dark:text-gray-400" x-text="search ? '{{ __('filament-log-viewer::log.modal.no_matching_entries') }}' : '{{ __('filament-log-viewer::log.modal.no_entries') }}'"></div>
+                <div x-show="filteredEntries.length === 0" class="p-8 text-center text-sm text-gray-500 dark:text-gray-400" x-text="search ? '{{ __('filament-log-viewer::log.table.modal.no_matching_entries') }}' : '{{ __('filament-log-viewer::log.table.modal.no_entries') }}'"></div>
                 <template x-for="(entry, index) in filteredEntries" :key="index">
                     <div class="p-5 hover:bg-gray-50 dark:hover:bg-gray-800/50">
                         <div class="flex flex-col gap-4">
@@ -105,7 +105,7 @@
                             <template x-if="entry.context">
                                 <details>
                                     <summary class="text-xs text-gray-500 dark:text-gray-400 cursor-pointer hover:text-gray-700 dark:hover:text-gray-300">
-                                        {{ __('filament-log-viewer::log.modal.context') }}
+                                        {{ __('filament-log-viewer::log.table.modal.context') }}
                                     </summary>
                                     <pre class="mt-2 p-3 text-xs bg-gray-100 dark:bg-gray-900 rounded overflow-x-auto font-mono whitespace-pre-wrap break-words" x-text="entry.context"></pre>
                                 </details>
@@ -113,7 +113,7 @@
                             <template x-if="entry.stack">
                                 <details>
                                     <summary class="text-xs text-gray-500 dark:text-gray-400 cursor-pointer hover:text-gray-700 dark:hover:text-gray-300">
-                                        {{ __('filament-log-viewer::log.modal.stack_trace') }}
+                                        {{ __('filament-log-viewer::log.table.modal.stack_trace') }}
                                     </summary>
                                     <pre class="mt-2 p-3 text-xs bg-gray-100 dark:bg-gray-900 rounded overflow-x-auto font-mono whitespace-pre-wrap break-words" x-text="entry.stack"></pre>
                                 </details>

--- a/resources/views/log-viewer-modal.blade.php
+++ b/resources/views/log-viewer-modal.blade.php
@@ -1,0 +1,129 @@
+@php
+    $log = $log ?? null;
+    $timezone = $timezone ?? config('app.timezone');
+    $entries = $log?->toModel() ?? [];
+    $levelColors = config('filament-log-viewer.colors.levels', []);
+@endphp
+@if ($log)
+    <div class="space-y-4">
+        <div class="rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50 p-4">
+            <dl class="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4 text-sm">
+                <div>
+                    <dt class="font-medium text-gray-500 dark:text-gray-400">{{ __('filament-log-viewer::log.table.detail.file_path') }}</dt>
+                    <dd class="mt-1 text-gray-900 dark:text-gray-100 break-all">{{ $log->path() }}</dd>
+                </div>
+                <div>
+                    <dt class="font-medium text-gray-500 dark:text-gray-400">{{ __('filament-log-viewer::log.table.detail.log_entries') }}</dt>
+                    <dd class="mt-1 text-gray-900 dark:text-gray-100">{{ $log->entries()->count() }}</dd>
+                </div>
+                <div>
+                    <dt class="font-medium text-gray-500 dark:text-gray-400">{{ __('filament-log-viewer::log.table.detail.size') }}</dt>
+                    <dd class="mt-1 text-gray-900 dark:text-gray-100">{{ $log->size() }}</dd>
+                </div>
+                <div>
+                    <dt class="font-medium text-gray-500 dark:text-gray-400">{{ __('filament-log-viewer::log.table.detail.updated_at') }}</dt>
+                    <dd class="mt-1 text-gray-900 dark:text-gray-100">{{ $log->updatedAt() }} <span class="text-gray-400">({{ $timezone }})</span></dd>
+                </div>
+            </dl>
+        </div>
+
+        <div
+            x-data="{
+                search: '',
+                scrollContainer: null,
+                levelColors: {{ json_encode($levelColors) }},
+                get filteredEntries() {
+                    const term = this.search.toLowerCase();
+                    if (!term) return {{ json_encode($entries) }};
+                    return {{ json_encode($entries) }}.filter(e => {
+                        const text = [
+                            e.level ?? '',
+                            e.datetime ?? '',
+                            e.header ?? '',
+                            e.stack ?? '',
+                            e.context ?? ''
+                        ].join(' ').toLowerCase();
+                        return text.includes(term);
+                    });
+                },
+                getColor(level) {
+                    return this.levelColors[level] ?? '#6B7280';
+                },
+                scrollToTop() {
+                    this.$refs.scrollContainer?.scrollTo({ top: 0, behavior: 'smooth' });
+                },
+                scrollToBottom() {
+                    const el = this.$refs.scrollContainer;
+                    if (el) el.scrollTo({ top: el.scrollHeight, behavior: 'smooth' });
+                }
+            }"
+            class="rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden"
+        >
+            <div class="flex items-center gap-2 p-3 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50">
+                <div class="flex-1 relative">
+                    <input
+                        type="search"
+                        x-model="search"
+                        placeholder="{{ __('filament-log-viewer::log.modal.search_placeholder') }}"
+                        class="w-full rounded-lg border-gray-300 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 text-sm px-4 py-2.5 focus:border-primary-500 focus:ring-primary-500"
+                    />
+                </div>
+                <button
+                    type="button"
+                    @click="scrollToTop"
+                    class="shrink-0 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-xs font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700"
+                    title="{{ __('filament-log-viewer::log.modal.go_to_top') }}"
+                >
+                    ↑ {{ __('filament-log-viewer::log.modal.top') }}
+                </button>
+                <button
+                    type="button"
+                    @click="scrollToBottom"
+                    class="shrink-0 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-xs font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700"
+                    title="{{ __('filament-log-viewer::log.modal.go_to_bottom') }}"
+                >
+                    ↓ {{ __('filament-log-viewer::log.modal.bottom') }}
+                </button>
+            </div>
+            <div
+                x-ref="scrollContainer"
+                class="max-h-[32rem] overflow-y-auto divide-y divide-gray-200 dark:divide-gray-700"
+            >
+                <div x-show="filteredEntries.length === 0" class="p-8 text-center text-sm text-gray-500 dark:text-gray-400" x-text="search ? '{{ __('filament-log-viewer::log.modal.no_matching_entries') }}' : '{{ __('filament-log-viewer::log.modal.no_entries') }}'"></div>
+                <template x-for="(entry, index) in filteredEntries" :key="index">
+                    <div class="p-5 hover:bg-gray-50 dark:hover:bg-gray-800/50">
+                        <div class="flex flex-col gap-4">
+                            <div class="flex items-center gap-2">
+                                <span
+                                    class="inline-flex items-center rounded px-2 py-0.5 text-xs font-medium shrink-0"
+                                    :style="`background-color: ${getColor(entry.level || 'info')}20; color: ${getColor(entry.level || 'info')}`"
+                                    x-text="(entry.level || 'info').toUpperCase()"
+                                ></span>
+                                <span class="text-xs text-gray-500 dark:text-gray-400" x-text="entry.datetime || ''"></span>
+                            </div>
+                            <p class="text-sm text-gray-900 dark:text-gray-100 break-words" x-text="entry.header || ''"></p>
+                            <template x-if="entry.context">
+                                <details>
+                                    <summary class="text-xs text-gray-500 dark:text-gray-400 cursor-pointer hover:text-gray-700 dark:hover:text-gray-300">
+                                        {{ __('filament-log-viewer::log.modal.context') }}
+                                    </summary>
+                                    <pre class="mt-2 p-3 text-xs bg-gray-100 dark:bg-gray-900 rounded overflow-x-auto font-mono whitespace-pre-wrap break-words" x-text="entry.context"></pre>
+                                </details>
+                            </template>
+                            <template x-if="entry.stack">
+                                <details>
+                                    <summary class="text-xs text-gray-500 dark:text-gray-400 cursor-pointer hover:text-gray-700 dark:hover:text-gray-300">
+                                        {{ __('filament-log-viewer::log.modal.stack_trace') }}
+                                    </summary>
+                                    <pre class="mt-2 p-3 text-xs bg-gray-100 dark:bg-gray-900 rounded overflow-x-auto font-mono whitespace-pre-wrap break-words" x-text="entry.stack"></pre>
+                                </details>
+                            </template>
+                        </div>
+                    </div>
+                </template>
+            </div>
+        </div>
+    </div>
+@else
+    <p class="text-sm text-gray-500 dark:text-gray-400">{{ __('filament-log-viewer::log.table.detail.title') }}</p>
+@endif

--- a/src/Actions/ViewLogModalAction.php
+++ b/src/Actions/ViewLogModalAction.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Boquizo\FilamentLogViewer\Actions;
+
+use Boquizo\FilamentLogViewer\FilamentLogViewerPlugin;
+use Boquizo\FilamentLogViewer\UseCases\ParseDateUseCase;
+use Filament\Actions\Action;
+use Illuminate\Contracts\View\View;
+
+class ViewLogModalAction
+{
+    public static function make(): Action
+    {
+        return Action::make('viewLog')
+            ->hiddenLabel()
+            ->button()
+            ->icon('heroicon-o-eye')
+            ->label(__('filament-log-viewer::log.table.actions.view.label'))
+            ->color('info')
+            ->modalHeading(fn (Action $action): string => (string) ParseDateUseCase::execute(
+                self::getRecordDate($action)
+            ))
+            ->modalWidth('7xl')
+            ->modalSubmitAction(false)
+            ->modalCancelActionLabel(__('filament-log-viewer::log.table.actions.close.label'))
+            ->modalContent(fn (Action $action): View => view('filament-log-viewer::log-viewer-modal', [
+                'log' => FilamentLogViewerPlugin::get()->getLogViewerRecord(self::getRecordDate($action)),
+                'timezone' => config('app.timezone'),
+            ]));
+    }
+
+    private static function getRecordDate(Action $action): string
+    {
+        $record = $action->getRecord();
+
+        if (is_array($record)) {
+            return $record['date'] ?? '';
+        }
+
+        return $record?->date ?? '';
+    }
+}

--- a/src/FilamentLogViewerPlugin.php
+++ b/src/FilamentLogViewerPlugin.php
@@ -115,6 +115,13 @@ class FilamentLogViewerPlugin implements Plugin
         return $this;
     }
 
+    public function viewInModal(bool $viewInModal = true): static
+    {
+        Config::set('filament-log-viewer.view_in_modal', $viewInModal);
+
+        return $this;
+    }
+
     public function getViewLog(): string
     {
         return $this->evaluate($this->viewLog);

--- a/src/Tables/LogsTable.php
+++ b/src/Tables/LogsTable.php
@@ -11,6 +11,7 @@ use Boquizo\FilamentLogViewer\Actions\DeleteBulkAction;
 use Boquizo\FilamentLogViewer\Actions\DownloadAction;
 use Boquizo\FilamentLogViewer\Actions\DownloadBulkAction;
 use Boquizo\FilamentLogViewer\Actions\ViewLogAction;
+use Boquizo\FilamentLogViewer\Actions\ViewLogModalAction;
 use Boquizo\FilamentLogViewer\FilamentLogViewerPlugin;
 use Boquizo\FilamentLogViewer\Tables\Columns\LevelColumn;
 use Boquizo\FilamentLogViewer\Tables\Columns\NameColumn;
@@ -47,7 +48,9 @@ class LogsTable
                 LevelColumn::make(Level::Debug),
             ])
             ->recordActions([
-                ViewLogAction::make(),
+                Config::get('filament-log-viewer.view_in_modal', false)
+                    ? ViewLogModalAction::make()
+                    : ViewLogAction::make(),
                 DownloadAction::make(),
                 ClearLogAction::make(),
                 DeleteAction::make(),


### PR DESCRIPTION
## Add log viewer modal option

### Summary

Adds an option to view logs in a modal instead of navigating to a full page, so users can inspect log contents without leaving the list.

### Changes

**New files**
- `src/Actions/ViewLogModalAction.php` – Action that opens the log in a modal
- `resources/views/log-viewer-modal.blade.php` – Modal view with:
  - Log metadata (path, entries count, size, updated at)
  - Search
  - Scroll to top/bottom
  - Log entries with level, datetime, message, context, and stack trace

**Modified files**
- `config/filament-log-viewer.php` – Added `view_in_modal` option (default: `false`)
- `src/Tables/LogsTable.php` – Uses `ViewLogModalAction` when `view_in_modal` is enabled
- `src/FilamentLogViewerPlugin.php` – Added `viewInModal(bool $viewInModal = true)` method
- `resources/lang/*/log.php` – Added `table.modal` translations (en, de, fr, es, it, pt, pl, ru, ar)
- `README.md` – Documented the modal feature

### Usage

**Via config** (`.env`):

### Screenshot
<img width="1335" height="896" alt="image" src="https://github.com/user-attachments/assets/5084d757-7520-4930-8c50-4d17ca770fa8" />

